### PR TITLE
Remove keyspace name in cql when creating tables

### DIFF
--- a/src/main/resources/cgmes_boundary.cql
+++ b/src/main/resources/cgmes_boundary.cql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS cgmes_boundary.boundaries (
+CREATE TABLE IF NOT EXISTS boundaries (
     id text,
     filename text,
     boundary blob,
@@ -6,13 +6,13 @@ CREATE TABLE IF NOT EXISTS cgmes_boundary.boundaries (
     PRIMARY KEY (id)
 );
 
-CREATE TABLE IF NOT EXISTS cgmes_boundary.tsos (
+CREATE TABLE IF NOT EXISTS tsos (
     name text,
     tsos blob,
     PRIMARY KEY (name)
 );
 
-CREATE TABLE IF NOT EXISTS cgmes_boundary.business_processes (
+CREATE TABLE IF NOT EXISTS business_processes (
     name text,
     businessProcesses blob,
     PRIMARY KEY (name)

--- a/src/test/java/org/gridsuite/cgmes/boundary/test/EmbeddedCassandraFactoryConfig.java
+++ b/src/test/java/org/gridsuite/cgmes/boundary/test/EmbeddedCassandraFactoryConfig.java
@@ -41,7 +41,7 @@ public class EmbeddedCassandraFactoryConfig {
     @Bean
     CassandraConnection cassandraConnection(Cassandra cassandra) {
         CassandraConnection cassandraConnection = new DefaultCassandraConnectionFactory().create(cassandra);
-        CqlDataSet.ofClasspaths("create_keyspace.cql", "cgmes_boundary.cql").forEachStatement(cassandraConnection::execute);
+        CqlDataSet.ofClasspaths("create_keyspace.cql").add(CqlDataSet.ofStrings("USE cgmes_boundary;")).add(CqlDataSet.ofClasspaths("cgmes_boundary.cql")).forEachStatement(cassandraConnection::execute);
         return cassandraConnection;
     }
 


### PR DESCRIPTION
otherwise it can't work with other keyspace name (ex: prefixed names)